### PR TITLE
Add clientbound networking

### DIFF
--- a/src/main/java/xyz/nucleoid/creator_tools/CreatorTools.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/CreatorTools.java
@@ -4,12 +4,15 @@ import com.google.common.reflect.Reflection;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xyz.nucleoid.creator_tools.command.MapManageCommand;
 import xyz.nucleoid.creator_tools.command.MapMetadataCommand;
 import xyz.nucleoid.creator_tools.item.CreatorToolsItems;
 import xyz.nucleoid.creator_tools.workspace.MapWorkspaceManager;
+import xyz.nucleoid.creator_tools.workspace.WorkspaceTraveler;
+import xyz.nucleoid.creator_tools.workspace.editor.WorkspaceNetworking;
 
 public final class CreatorTools implements ModInitializer {
     public static final String ID = "nucleoid_creator_tools";
@@ -27,6 +30,11 @@ public final class CreatorTools implements ModInitializer {
 
         ServerTickEvents.START_SERVER_TICK.register(server -> {
             MapWorkspaceManager.get(server).tick();
+        });
+
+        ServerPlayNetworking.registerGlobalReceiver(WorkspaceNetworking.OPT_IN_ID, (server, player, handler, buf, responseSender) -> {
+            int protocolVersion = buf.readVarInt();
+            WorkspaceTraveler.setCreatorToolsProtocolVersion(player, protocolVersion);
         });
     }
 }

--- a/src/main/java/xyz/nucleoid/creator_tools/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/mixin/ServerPlayerEntityMixin.java
@@ -27,6 +27,7 @@ import xyz.nucleoid.creator_tools.CreatorTools;
 import xyz.nucleoid.creator_tools.workspace.MapWorkspaceManager;
 import xyz.nucleoid.creator_tools.workspace.ReturnPosition;
 import xyz.nucleoid.creator_tools.workspace.WorkspaceTraveler;
+import xyz.nucleoid.creator_tools.workspace.editor.WorkspaceNetworking;
 
 import java.util.Map;
 
@@ -38,6 +39,8 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Wo
 
     private ReturnPosition leaveReturn;
     private final Map<RegistryKey<World>, ReturnPosition> workspaceReturns = new Reference2ObjectOpenHashMap<>();
+
+    private int creatorToolsProtocolVersion = WorkspaceNetworking.NO_PROTOCOL_VERSION;
 
     private ServerPlayerEntityMixin(World world, BlockPos blockPos, float yaw, GameProfile gameProfile, @Nullable PlayerPublicKey publicKey) {
         super(world, blockPos, yaw, gameProfile, publicKey);
@@ -89,6 +92,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Wo
         this.leaveReturn = fromTraveler.leaveReturn;
         this.workspaceReturns.clear();
         this.workspaceReturns.putAll(fromTraveler.workspaceReturns);
+        this.creatorToolsProtocolVersion = fromTraveler.creatorToolsProtocolVersion;
     }
 
     @Inject(method = "teleport", at = @At("HEAD"))
@@ -123,5 +127,15 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Wo
     @Override
     public ReturnPosition getLeaveReturn() {
         return this.leaveReturn;
+    }
+
+    @Override
+    public int getCreatorToolsProtocolVersion() {
+        return this.creatorToolsProtocolVersion;
+    }
+
+    @Override
+    public void setCreatorToolsProtocolVersion(int protocolVersion) {
+        this.creatorToolsProtocolVersion = protocolVersion;
     }
 }

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/MapWorkspace.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/MapWorkspace.java
@@ -178,6 +178,10 @@ public final class MapWorkspace {
      */
     public void setData(NbtCompound data) {
         this.data = data;
+
+        for (var listener : this.listeners) {
+            listener.onSetData(data);
+        }
     }
 
     public NbtCompound serialize(NbtCompound root) {

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/WorkspaceListener.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/WorkspaceListener.java
@@ -1,5 +1,6 @@
 package xyz.nucleoid.creator_tools.workspace;
 
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.math.BlockPos;
 import xyz.nucleoid.map_templates.BlockBounds;
 
@@ -8,6 +9,9 @@ public interface WorkspaceListener {
     }
 
     default void onSetOrigin(BlockPos origin) {
+    }
+
+    default void onSetData(NbtCompound data) {
     }
 
     default void onAddRegion(WorkspaceRegion region) {

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/WorkspaceTraveler.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/WorkspaceTraveler.java
@@ -3,6 +3,7 @@ package xyz.nucleoid.creator_tools.workspace;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
+import xyz.nucleoid.creator_tools.workspace.editor.WorkspaceNetworking;
 import org.jetbrains.annotations.Nullable;
 
 public interface WorkspaceTraveler {
@@ -22,9 +23,26 @@ public interface WorkspaceTraveler {
         return null;
     }
 
+    static int getCreatorToolsProtocolVersion(ServerPlayerEntity player) {
+        if (player instanceof WorkspaceTraveler traveler) {
+            return traveler.getCreatorToolsProtocolVersion();
+        }
+        return WorkspaceNetworking.NO_PROTOCOL_VERSION;
+    }
+
+    static void setCreatorToolsProtocolVersion(ServerPlayerEntity player, int protocolVersion) {
+        if (player instanceof WorkspaceTraveler traveler) {
+            traveler.setCreatorToolsProtocolVersion(protocolVersion);
+        }
+    }
+
     @Nullable
     ReturnPosition getReturnFor(RegistryKey<World> dimension);
 
     @Nullable
     ReturnPosition getLeaveReturn();
+
+    int getCreatorToolsProtocolVersion();
+
+    void setCreatorToolsProtocolVersion(int protocolVersion);
 }

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/NetworkedWorkspaceEditor.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/NetworkedWorkspaceEditor.java
@@ -46,7 +46,7 @@ public class NetworkedWorkspaceEditor implements WorkspaceEditor {
                 buf.writeString(entry.getKey());
 
                 for (var region : entry.getValue()) {
-                    buf.writeInt(region.runtimeId());
+                    buf.writeVarInt(region.runtimeId());
                     WorkspaceNetworking.writeBounds(buf, region.bounds());
                     buf.writeNbt(region.data());
                 }
@@ -74,7 +74,7 @@ public class NetworkedWorkspaceEditor implements WorkspaceEditor {
     public void removeRegion(WorkspaceRegion region) {
         if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGION_REMOVE_ID)) {
             var buf = PacketByteBufs.create();
-            buf.writeInt(region.runtimeId());
+            buf.writeVarInt(region.runtimeId());
             this.sendPacket(WorkspaceNetworking.WORKSPACE_REGION_REMOVE_ID, buf);
         }
     }
@@ -120,7 +120,7 @@ public class NetworkedWorkspaceEditor implements WorkspaceEditor {
         if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGION_ID)) {
             var buf = PacketByteBufs.create();
 
-            buf.writeInt(region.runtimeId());
+            buf.writeVarInt(region.runtimeId());
             WorkspaceNetworking.writeRegion(buf, region);
 
             this.sendPacket(WorkspaceNetworking.WORKSPACE_REGION_ID, buf);

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/NetworkedWorkspaceEditor.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/NetworkedWorkspaceEditor.java
@@ -1,0 +1,132 @@
+package xyz.nucleoid.creator_tools.workspace.editor;
+
+import java.util.stream.Collectors;
+
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.creator_tools.workspace.MapWorkspace;
+import xyz.nucleoid.creator_tools.workspace.WorkspaceRegion;
+import xyz.nucleoid.map_templates.BlockBounds;
+
+/**
+ * An editor implementation that uses {@linkplain WorkspaceNetworking networking} for use with clientside mods.
+ */
+public class NetworkedWorkspaceEditor implements WorkspaceEditor {
+    private final ServerPlayerEntity player;
+    private final MapWorkspace workspace;
+
+    public NetworkedWorkspaceEditor(ServerPlayerEntity player, MapWorkspace workspace) {
+        this.player = player;
+        this.workspace = workspace;
+    }
+
+    @Override
+    public void onEnter() {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_ENTER_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            WorkspaceNetworking.writeBounds(buf, this.workspace.getBounds());
+            buf.writeIdentifier(this.workspace.getWorld().getRegistryKey().getValue());
+            buf.writeNbt(this.workspace.getData());
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_ENTER_ID, buf);
+        }
+
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGIONS_ID)) {
+            var groups = this.workspace.getRegions().stream().collect(Collectors.groupingBy(WorkspaceRegion::marker));
+
+            for (var entry : groups.entrySet()) {
+                var buf = PacketByteBufs.create();
+
+                buf.writeString(entry.getKey());
+
+                for (var region : entry.getValue()) {
+                    buf.writeInt(region.runtimeId());
+                    WorkspaceNetworking.writeBounds(buf, region.bounds());
+                    buf.writeNbt(region.data());
+                }
+
+                this.sendPacket(WorkspaceNetworking.WORKSPACE_REGIONS_ID, buf);
+            }
+        }
+    }
+
+    @Override
+    public void onLeave() {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_LEAVE_ID)) {
+            var buf = PacketByteBufs.create();
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_LEAVE_ID, buf);
+        }
+    }
+
+    @Override
+    public void addRegion(WorkspaceRegion region) {
+        this.sendRegionPacket(region);
+    }
+
+    @Override
+    public void removeRegion(WorkspaceRegion region) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGION_REMOVE_ID)) {
+            var buf = PacketByteBufs.create();
+            buf.writeInt(region.runtimeId());
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_REGION_REMOVE_ID, buf);
+        }
+    }
+
+    @Override
+    public void updateRegion(WorkspaceRegion lastRegion, WorkspaceRegion newRegion) {
+        this.sendRegionPacket(newRegion);
+    }
+
+    @Override
+    public void setBounds(BlockBounds bounds) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_BOUNDS_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            WorkspaceNetworking.writeBounds(buf, bounds);
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_BOUNDS_ID, buf);
+        }
+    }
+
+    @Override
+    public void setData(NbtCompound data) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_DATA_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            buf.writeNbt(data);
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_DATA_ID, buf);
+        }
+    }
+
+    private boolean canSendPacket(Identifier channel) {
+        return ServerPlayNetworking.canSend(this.player, channel);
+    }
+
+    private void sendPacket(Identifier channel, PacketByteBuf buf) {
+        ServerPlayNetworking.send(this.player, channel, buf);
+    }
+
+    private boolean sendRegionPacket(WorkspaceRegion region) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGION_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeInt(region.runtimeId());
+            WorkspaceNetworking.writeRegion(buf, region);
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_REGION_ID, buf);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/ServersideWorkspaceEditor.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/ServersideWorkspaceEditor.java
@@ -3,13 +3,18 @@ package xyz.nucleoid.creator_tools.workspace.editor;
 import it.unimi.dsi.fastutil.HashCommon;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.creator_tools.workspace.MapWorkspace;
 import xyz.nucleoid.creator_tools.workspace.WorkspaceRegion;
@@ -18,6 +23,7 @@ import xyz.nucleoid.creator_tools.workspace.trace.RegionTraceMode;
 import xyz.nucleoid.map_templates.BlockBounds;
 
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public final class ServersideWorkspaceEditor implements WorkspaceEditor {
     private static final int PARTICLE_INTERVAL = 10;
@@ -45,6 +51,47 @@ public final class ServersideWorkspaceEditor implements WorkspaceEditor {
         markerEntity.setMarker(true);
         markerEntity.setCustomNameVisible(true);
         this.markerEntity = markerEntity;
+    }
+
+    @Override
+    public void onEnter() {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_ENTER_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            WorkspaceNetworking.writeBounds(buf, this.workspace.getBounds());
+            buf.writeIdentifier(this.workspace.getWorld().getRegistryKey().getValue());
+            buf.writeNbt(this.workspace.getData());
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_ENTER_ID, buf);
+        }
+
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGIONS_ID)) {
+            var groups = this.workspace.getRegions().stream().collect(Collectors.groupingBy(WorkspaceRegion::marker));
+
+            for (var entry : groups.entrySet()) {
+                var buf = PacketByteBufs.create();
+
+                buf.writeString(entry.getKey());
+
+                for (var region : entry.getValue()) {
+                    buf.writeInt(region.runtimeId());
+                    WorkspaceNetworking.writeBounds(buf, region.bounds());
+                    buf.writeNbt(region.data());
+                }
+
+                this.sendPacket(WorkspaceNetworking.WORKSPACE_REGIONS_ID, buf);
+            }
+        }
+    }
+
+    @Override
+    public void onLeave() {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_LEAVE_ID)) {
+            var buf = PacketByteBufs.create();
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_LEAVE_ID, buf);
+        }
     }
 
     @Override
@@ -104,38 +151,73 @@ public final class ServersideWorkspaceEditor implements WorkspaceEditor {
     @Override
     public void addRegion(WorkspaceRegion region) {
         var marker = this.nextMarkerIds();
-        var markerPos = region.bounds().center();
 
-        var markerEntity = marker.applyTo(this.markerEntity);
-        markerEntity.setPos(markerPos.x, markerPos.y, markerPos.z);
-        markerEntity.setCustomName(Text.literal(region.marker()));
+        if (!this.sendRegionPacket(region)) {
+            var markerPos = region.bounds().center();
 
-        var networkHandler = this.player.networkHandler;
-        networkHandler.sendPacket(markerEntity.createSpawnPacket());
-        networkHandler.sendPacket(new EntityTrackerUpdateS2CPacket(marker.id(), markerEntity.getDataTracker(), true));
+            var markerEntity = marker.applyTo(this.markerEntity);
+            markerEntity.setPos(markerPos.x, markerPos.y, markerPos.z);
+            markerEntity.setCustomName(Text.literal(region.marker()));
+
+            var networkHandler = this.player.networkHandler;
+            networkHandler.sendPacket(markerEntity.createSpawnPacket());
+            networkHandler.sendPacket(new EntityTrackerUpdateS2CPacket(marker.id(), markerEntity.getDataTracker(), true));
+        }
 
         this.regionToMarker.put(region.runtimeId(), marker);
     }
 
     @Override
     public void removeRegion(WorkspaceRegion region) {
-        var marker = this.regionToMarker.remove(region.runtimeId());
-        if (marker != null) {
-            this.player.networkHandler.sendPacket(new EntitiesDestroyS2CPacket(marker.id()));
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGION_REMOVE_ID)) {
+            var buf = PacketByteBufs.create();
+            buf.writeInt(region.runtimeId());
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_REGION_REMOVE_ID, buf);
+        } else {
+            var marker = this.regionToMarker.remove(region.runtimeId());
+            if (marker != null) {
+                this.player.networkHandler.sendPacket(new EntitiesDestroyS2CPacket(marker.id()));
+            }
         }
     }
 
     @Override
     public void updateRegion(WorkspaceRegion lastRegion, WorkspaceRegion newRegion) {
-        var marker = this.regionToMarker.get(newRegion.runtimeId());
-        if (marker == null) {
-            return;
+        if (!this.sendRegionPacket(newRegion)) {
+            var marker = this.regionToMarker.get(newRegion.runtimeId());
+            if (marker == null) {
+                return;
+            }
+
+            var markerEntity = marker.applyTo(this.markerEntity);
+            markerEntity.setCustomName(Text.literal(newRegion.marker()));
+
+            this.player.networkHandler.sendPacket(new EntityTrackerUpdateS2CPacket(marker.id(), markerEntity.getDataTracker(), true));
         }
+    }
 
-        var markerEntity = marker.applyTo(this.markerEntity);
-        markerEntity.setCustomName(Text.literal(newRegion.marker()));
+    @Override
+    public void setBounds(BlockBounds bounds) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_BOUNDS_ID)) {
+            var buf = PacketByteBufs.create();
 
-        this.player.networkHandler.sendPacket(new EntityTrackerUpdateS2CPacket(marker.id(), markerEntity.getDataTracker(), true));
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            WorkspaceNetworking.writeBounds(buf, bounds);
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_BOUNDS_ID, buf);
+        }
+    }
+
+    @Override
+    public void setData(NbtCompound data) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_DATA_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeIdentifier(this.workspace.getIdentifier());
+            buf.writeNbt(data);
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_DATA_ID, buf);
+        }
     }
 
     private Marker nextMarkerIds() {
@@ -178,6 +260,28 @@ public final class ServersideWorkspaceEditor implements WorkspaceEditor {
         } else if (traced != null) {
             ParticleOutlineRenderer.render(this.player, traced.min(), traced.max(), 0.1F, 1.0F, 0.1F);
         }
+    }
+
+    private boolean canSendPacket(Identifier channel) {
+        return ServerPlayNetworking.canSend(this.player, channel);
+    }
+
+    private void sendPacket(Identifier channel, PacketByteBuf buf) {
+        ServerPlayNetworking.send(this.player, channel, buf);
+    }
+
+    private boolean sendRegionPacket(WorkspaceRegion region) {
+        if (this.canSendPacket(WorkspaceNetworking.WORKSPACE_REGION_ID)) {
+            var buf = PacketByteBufs.create();
+
+            buf.writeInt(region.runtimeId());
+            WorkspaceNetworking.writeRegion(buf, region);
+
+            this.sendPacket(WorkspaceNetworking.WORKSPACE_REGION_ID, buf);
+            return true;
+        }
+
+        return false;
     }
 
     private static int colorForRegionMarker(String marker) {

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceEditor.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceEditor.java
@@ -1,5 +1,6 @@
 package xyz.nucleoid.creator_tools.workspace.editor;
 
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.creator_tools.workspace.WorkspaceRegion;
@@ -21,6 +22,9 @@ public interface WorkspaceEditor {
     default void setOrigin(BlockPos origin) {
     }
 
+    default void setData(NbtCompound data) {
+    }
+
     default boolean useRegionItem() {
         return false;
     }
@@ -28,6 +32,12 @@ public interface WorkspaceEditor {
     @Nullable
     default BlockBounds takeTracedRegion() {
         return null;
+    }
+
+    default void onEnter() {
+    }
+
+    default void onLeave() {
     }
 
     default void tick() {

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceEditorManager.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceEditorManager.java
@@ -2,6 +2,7 @@ package xyz.nucleoid.creator_tools.workspace.editor;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
@@ -29,7 +30,10 @@ public final class WorkspaceEditorManager {
     public void onPlayerRemoveFromWorld(ServerPlayerEntity player, ServerWorld world) {
         var workspace = this.workspaces.get(world.getRegistryKey());
         if (workspace != null) {
-            workspace.editors.remove(player.getUuid());
+            var editor = workspace.editors.remove(player.getUuid());
+            if (editor != null) {
+                editor.onLeave();
+            }
         }
     }
 
@@ -75,6 +79,8 @@ public final class WorkspaceEditorManager {
         void addEditor(ServerPlayerEntity player, WorkspaceEditor editor) {
             this.editors.put(player.getUuid(), editor);
 
+            editor.onEnter();
+
             editor.setOrigin(this.workspace.getOrigin());
             editor.setBounds(this.workspace.getBounds());
 
@@ -100,6 +106,13 @@ public final class WorkspaceEditorManager {
         public void onSetOrigin(BlockPos origin) {
             for (var editor : this.editors.values()) {
                 editor.setOrigin(origin);
+            }
+        }
+
+        @Override
+        public void onSetData(NbtCompound data) {
+            for (var editor : this.editors.values()) {
+                editor.setData(data);
             }
         }
 

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceEditorManager.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceEditorManager.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.creator_tools.workspace.MapWorkspace;
 import xyz.nucleoid.creator_tools.workspace.WorkspaceListener;
 import xyz.nucleoid.creator_tools.workspace.WorkspaceRegion;
+import xyz.nucleoid.creator_tools.workspace.WorkspaceTraveler;
 import xyz.nucleoid.map_templates.BlockBounds;
 
 import java.util.Map;
@@ -55,7 +56,8 @@ public final class WorkspaceEditorManager {
     }
 
     private WorkspaceEditor createEditorFor(ServerPlayerEntity player, MapWorkspace workspace) {
-        return new ServersideWorkspaceEditor(player, workspace);
+        int protocolVersion = WorkspaceTraveler.getCreatorToolsProtocolVersion(player);
+        return protocolVersion == 1 ? new NetworkedWorkspaceEditor(player, workspace) : new ServersideWorkspaceEditor(player, workspace);
     }
 
     @Nullable

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceNetworking.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceNetworking.java
@@ -1,0 +1,39 @@
+package xyz.nucleoid.creator_tools.workspace.editor;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import xyz.nucleoid.creator_tools.CreatorTools;
+import xyz.nucleoid.creator_tools.workspace.WorkspaceRegion;
+import xyz.nucleoid.map_templates.BlockBounds;
+
+public final class WorkspaceNetworking {
+    // Client <-> Server
+    public static final Identifier WORKSPACE_LEAVE_ID = new Identifier(CreatorTools.ID, "workspace/leave");
+    public static final Identifier WORKSPACE_BOUNDS_ID = new Identifier(CreatorTools.ID, "workspace/bounds");
+    public static final Identifier WORKSPACE_DATA_ID = new Identifier(CreatorTools.ID, "workspace/data");
+    public static final Identifier WORKSPACE_REGION_ID = new Identifier(CreatorTools.ID, "workspace/region");
+    public static final Identifier WORKSPACE_REGION_REMOVE_ID = new Identifier(CreatorTools.ID, "workspace/region/remove");
+
+    // Client <-- Server
+    public static final Identifier WORKSPACE_ENTER_ID = new Identifier(CreatorTools.ID, "workspace/enter");
+    public static final Identifier WORKSPACE_REGIONS_ID = new Identifier(CreatorTools.ID, "workspace/regions");
+
+    // Client --> Server
+    public static final Identifier WORKSPACE_NEW_ID = new Identifier(CreatorTools.ID, "workspace/new");
+    public static final Identifier WORKSPACE_REGION_ADD_ID = new Identifier(CreatorTools.ID, "workspace/region/add");
+
+    private WorkspaceNetworking() {
+        return;
+    }
+
+    public static void writeBounds(PacketByteBuf buf, BlockBounds bounds) {
+        buf.writeBlockPos(bounds.min());
+        buf.writeBlockPos(bounds.max());
+    }
+
+    public static void writeRegion(PacketByteBuf buf, WorkspaceRegion region) {
+        buf.writeString(region.marker());
+        writeBounds(buf, region.bounds());
+        buf.writeNbt(region.data());
+    }
+}

--- a/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceNetworking.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/workspace/editor/WorkspaceNetworking.java
@@ -7,6 +7,8 @@ import xyz.nucleoid.creator_tools.workspace.WorkspaceRegion;
 import xyz.nucleoid.map_templates.BlockBounds;
 
 public final class WorkspaceNetworking {
+    public static final int NO_PROTOCOL_VERSION = -1;
+
     // Client <-> Server
     public static final Identifier WORKSPACE_LEAVE_ID = new Identifier(CreatorTools.ID, "workspace/leave");
     public static final Identifier WORKSPACE_BOUNDS_ID = new Identifier(CreatorTools.ID, "workspace/bounds");
@@ -19,6 +21,7 @@ public final class WorkspaceNetworking {
     public static final Identifier WORKSPACE_REGIONS_ID = new Identifier(CreatorTools.ID, "workspace/regions");
 
     // Client --> Server
+    public static final Identifier OPT_IN_ID = new Identifier(CreatorTools.ID, "opt_in");
     public static final Identifier WORKSPACE_NEW_ID = new Identifier(CreatorTools.ID, "workspace/new");
     public static final Identifier WORKSPACE_REGION_ADD_ID = new Identifier(CreatorTools.ID, "workspace/region/add");
 


### PR DESCRIPTION
This pull request adds clientbound networking, specifically to support the original [workspace-related packets documentation](https://github.com/NucleoidMC/plasmid/blob/dcda7f90177b958e04ea93c76690f4f37fafd8c1/doc/network.md#workspace-related-packets) by @LambdAurora.

Some things to note:

- Serverbound networking is not implemented
- The `nucleoid_creator_tools` namespace is used instead of `plasmid` because the packets are not relevant to Plasmid anymore
- Some data may be duplicated for now (for example, a workspace enter and a workspace bounds packet will be sent at the same time despite the enter packet already containing bounds)
- The workspace origin is not represented within any packet