### PR TITLE
Fixed lambda expression in `CreatorToolItems` to allow the mod to compile for 1.19.4-rc2

### DIFF
--- a/src/main/java/xyz/nucleoid/creator_tools/item/CreatorToolsItems.java
+++ b/src/main/java/xyz/nucleoid/creator_tools/item/CreatorToolsItems.java
@@ -16,7 +16,7 @@ public final class CreatorToolsItems {
     public static final ItemGroup ITEM_GROUP = PolymerItemGroupUtils.builder(CreatorTools.identifier("general"))
         .displayName(Text.translatable("text.nucleoid_creator_tools.name"))
         .icon(ADD_REGION::getDefaultStack)
-        .entries((enabledFeatures, entries, operatorEnabled) -> {
+        .entries((context, entries) -> {
             entries.add(ADD_REGION);
             entries.add(INCLUDE_ENTITY);
             entries.add(REGION_VISIBILITY_FILTER);


### PR DESCRIPTION
Changed lambda expression number of arguments to allow the mod to compile. Changed `enabledFeatures` name of one argument in the lambda to `context`.