### PR TITLE
feat!: Force user to delete regions by name; introduce +all specifier

### DIFF
--- a/src/main/resources/data/nucleoid_creator_tools/lang/en_us.json
+++ b/src/main/resources/data/nucleoid_creator_tools/lang/en_us.json
@@ -47,6 +47,8 @@
   "text.nucleoid_creator_tools.map.open.map_already_exists": "Map with id '%s' already exists!",
   "text.nucleoid_creator_tools.map.open.success": "Opened workspace '%s'! Use %s to join this map",
   "text.nucleoid_creator_tools.map.origin.set": "Updated origin for workspace",
+  "text.nucleoid_creator_tools.map.region.reserved_name": "Region name '%s' is not allowed to begin with '+'.",
+  "text.nucleoid_creator_tools.map.region.selector.invalid": "Invalid region selector '%s'.",
   "text.nucleoid_creator_tools.map.region.add.success": "Added region '%s'.",
   "text.nucleoid_creator_tools.map.region.add.success.excited": "Added region '%s'!",
   "text.nucleoid_creator_tools.map.region.bounds.get": "%s to %s",


### PR DESCRIPTION
- Force the user to specify _which_ regions they want to remove with `/map region remove here <name>`. This is a **breaking change** with regard to the command syntax, as `<name>` is a required parameter.
- Allow most local regions to be specified by `+all` which includes all that the player is inside of.  This is a **breaking change** as now region markers beginning with `+` are invalid.

@haykam821: this is similar to what we discussed, but instead of using `@all` (`@` is not allowed in word string args), it uses `+all`, and then makes `+all` a reserved region name. Unfortunately I had to reintroduce this as siblings would be very messy and don't compose well at all.

Partially addresses #21
